### PR TITLE
ブロックのカテゴリ『文字列』の名称を変更

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -283,7 +283,7 @@
                 <block type="random_integer"></block>
             </category>
 
-            <category name="文字列" colour="#5ba58c">
+            <category name="文字列とコンソール" colour="#5ba58c">
                 <block type="text"></block>
                 <block type="text_join"></block>
                 <block type="text_length"></block>


### PR DESCRIPTION
文字列タブには文字列ブロックだけでなく、コンソール出力のブロックもあったため、『文字列』から『文字列とコンソール』に変えました。おそらく優先順位は超超低めです。
納得しなかったらこのプルリクエストを破棄してください。